### PR TITLE
Added key.ignoreEvent

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -86,7 +86,8 @@ key.setScope('issues'); // default scope is 'all'
 ## Notes
 
 When an `INPUT`, `SELECT` or `TEXTAREA` element is focused, Keymaster
-doesn't process shortcuts.
+doesn't process shortcuts. You can change this behavior by changing the
+`key.ignoreEvent` function.
 
 Keymaster should work with any browser that fires `keyup` and `keydown` events,
 and is tested with IE (6+), Safari, Firefox and Chrome.

--- a/keymaster.js
+++ b/keymaster.js
@@ -41,8 +41,7 @@
 
   // handle keydown event
   function dispatch(event){
-    var key, tagName, handler, k, i, modifiersMatch;
-    tagName = (event.target || event.srcElement).tagName;
+    var key, handler, k, i, modifiersMatch;
     key = event.keyCode;
 
     // if a modifier key, set the key.<modifierkeyname> property to true and return
@@ -54,8 +53,7 @@
       return;
     }
 
-    // ignore keypressed in any elements that support keyboard data input
-    if (tagName == 'INPUT' || tagName == 'SELECT' || tagName == 'TEXTAREA') return;
+    if (global.key.ignoreEvent(event)) { return; }
 
     // abort if no potentially matching shortcuts found
     if (!(key in _handlers)) return;
@@ -131,6 +129,12 @@
     }
   };
 
+  // ignore keypressed in any elements that support keyboard data input
+  function defaultIgnoreEvent(event) {
+    var tagName = (event.target || event.srcElement).tagName;
+    return tagName === 'INPUT' || tagName === 'SELECT' || tagName === 'TEXTAREA';
+  };
+
   // initialize key.<modifier> to false
   for(k in _MODIFIERS) assignKey[k] = false;
 
@@ -157,6 +161,7 @@
   global.key = assignKey;
   global.key.setScope = setScope;
   global.key.getScope = getScope;
+  global.key.ignoreEvent = defaultIgnoreEvent;
 
   if(typeof module !== 'undefined') module.exports = key;
 

--- a/test/keymaster.html
+++ b/test/keymaster.html
@@ -44,9 +44,15 @@
       '⌥': 18, alt: 18, option: 18,
       '⌃': 17, ctrl: 17, control: 17,
       '⌘': 91, command: 91
-    };
+    },
+
+    originalIgnoreEvent = key.ignoreEvent;
 
     Evidence.TestCase.extend('KeymasterTest', {
+      tearDown: function() {
+        key.ignoreEvent = originalIgnoreEvent;
+      },
+
       testShortcut: function(t){
         var cnt = 0;
         key('a', function(){ cnt++ });
@@ -166,6 +172,17 @@
         keydown(65, $('input_text'));
         keyup(65, $('input_text'));
         t.assertEqual(1, cnt);
+      },
+
+      testDoesntFireOnCustomIgnoredElements: function(t){
+        var cnt = 0;
+        key.ignoreEvent = function(event) { return false; };
+        key('a', function(){ cnt++; });
+        keydown(65, $('paragraph'));
+        keyup(65, $('paragraph'));
+        keydown(65, $('input_text'));
+        keyup(65, $('input_text'));
+        t.assertEqual(2, cnt);
       }
 
     });


### PR DESCRIPTION
The default behavior is still to ignore events from `<input>`s, `<select>`s, and `<textarea>`s, but that can be changed by setting `window.key.ignoreEvent` to a different function.
