### PR TITLE
Allows keys to be assigned to more than one scope

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -65,7 +65,7 @@
       handler = _handlers[key][i];
 
       // see if it's in the current scope
-      if(handler.scope == _scope || handler.scope == 'all'){
+      if(handler.scope.indexOf(_scope) > -1 || handler.scope == 'all'){
         // check if modifiers match if any
         modifiersMatch = handler.mods.length > 0;
         for(k in _mods)


### PR DESCRIPTION
Allows a handler to be assigned to multiple scopes like so:

``` javascript
key('c', 'hello, world', callback_function)
```

or

``` javascript
key('c', 'hello world', callback_function)
```
