### PR TITLE
reset modifiers to false on window focus. fixes alt+tab, tab switching, and related issues

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -94,6 +94,14 @@
     }
   };
 
+  function resetModifiers() {
+    for (k in _mods) {
+      if (_mods.hasOwnProperty(k)) {
+        _mods[k] = false;
+      }
+    }
+  }
+
   // parse and assign shortcut
   function assignKey(key, scope, method){
     var keys, mods, i, mi;
@@ -143,6 +151,9 @@
   // set the handlers globally on document
   addEvent(document, 'keydown', dispatch);
   addEvent(document, 'keyup', clearModifier);
+
+  // reset modifiers to false whenever the window is (re)focused.
+  addEvent(window, 'focus', resetModifiers);
 
   // set window.key and window.key.setScope
   global.key = assignKey;


### PR DESCRIPTION
proposed fix for issue #16, including these example problems:
- when I alt+tab away from the browser to another application, the window doesn't get the keyup events, so _mods[alt] stays true after I navigate back. to reproduce:

key('d', function () {
  console.log('pressed d!');
});

alt+tab to another program.
navigate back to the browser.
press 'd', nothing happens.
- same issue when I use shift+command+] to switch browser tabs on mac (or any other tab-switching shortcut that involves modifiers). 
- here's a sweet one :) same issue when i do:

key('ctrl+c', function () {
  alert('pressed ctrl+c!');
}) ;

alert() takes focus away from the window, so after i click 'ok', alert() will keep getting called every time I press 'c' without the modifier.

fix:

reset _mod values to false every time the window is focused.  i experimented with document vs window, and focus vs blur, and window focus is the only event that works for every scenario. tested on Chrome/FF/Safari.
