### PR TITLE
Defer setting of scope in setScope

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -141,7 +141,7 @@
   for(k in _MODIFIERS) assignKey[k] = false;
 
   // set current scope (default 'all')
-  function setScope(scope){ _scope = scope || 'all' };
+  function setScope(scope){ setTimeout(function(){ _scope = scope || 'all' }, 0) };
   function getScope(){ return _scope || 'all' };
 
   // delete all handlers for a given scope


### PR DESCRIPTION
... to prevent potential loop or calling callbacks from different scope for the same shortcut. Fixes #28. Fixes #48
