### PR TITLE
Fix invalid variable name `key` in commonjs environnement.

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -179,6 +179,6 @@
   global.key.deleteScope = deleteScope;
   global.key.filter = filter;
 
-  if(typeof module !== 'undefined') module.exports = global.key;
+  if(typeof module !== 'undefined') module.exports = assignKey;
 
 })(this);


### PR DESCRIPTION
Hello,

Look like a typo error : the exported value by keymaster in a commonjs environnement is a variable that do not longer exists : `key` : changed  to `assignKey`.
