### PR TITLE
module.exports = global.key

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -221,6 +221,6 @@
   global.key.getPressedKeyCodes = getPressedKeyCodes;
   global.key.noConflict = noConflict;
 
-  if(typeof module !== 'undefined') module.exports = key;
+  if(typeof module !== 'undefined') module.exports = global.key;
 
 })(this);


### PR DESCRIPTION
This is important to me. I would wrap the code with

``` javascript
define(function(require, exports, module) {
  var global = {};
  (function() {
    // keymaster code here
  }).call(global);
});
```

via https://github.com/seajs/gallery/blob/master/keymaster/src/keymaster.transport

BTW, can you git tag your repo please!

The code is changing, but the version is not.
