### PR TITLE
getPressedKeys() should return a clone of _downKeys

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -157,7 +157,7 @@
   }
 
   function getPressedKeyCodes() {
-      return _downKeys;
+      return _downKeys.slice(0);
   }
 
   function filter(event){

--- a/test/keymaster.html
+++ b/test/keymaster.html
@@ -244,8 +244,10 @@
       testGetPressedKeyCodes: function (t) {
         keydown(65); keydown(KEYS.shift);
         var pressedKeys = key.getPressedKeyCodes();
+        var otherKeys = key.getPressedKeyCodes();
         t.assertTrue(pressedKeys.indexOf(65) >= 0);
         t.assertTrue(pressedKeys.indexOf(16) >= 0);
+        t.assertTrue(pressedKeys != otherKeys);
         keyup(65); keyup(KEYS.shift);
       },
 


### PR DESCRIPTION
getPressedKeys() right now is returning the actual private _downKeys variable. This exposes internal state and is mutable.

The fix will only return a new Array. The test checks to make sure that the #getPressedKeys returns a new array whenever called.
