### PR TITLE
use !== vs != in test

### DIFF
--- a/test/keymaster.html
+++ b/test/keymaster.html
@@ -247,7 +247,7 @@
         var otherKeys = key.getPressedKeyCodes();
         t.assertTrue(pressedKeys.indexOf(65) >= 0);
         t.assertTrue(pressedKeys.indexOf(16) >= 0);
-        t.assertTrue(pressedKeys != otherKeys);
+        t.assertTrue(pressedKeys !== otherKeys);
         keyup(65); keyup(KEYS.shift);
       },
 


### PR DESCRIPTION
I noticed that the test should be using !== vs != since we dont want to do any type conversion
