### PR TITLE
unbind method + unit tests + method argument

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -174,9 +174,10 @@
   function getScope(){ return _scope || 'all'; }
 
   // unbind all handlers for given key in current scope
-  function unbindKey(key, scope) {
+  function unbindKey(key, scope, method) {
     key = _MAP[key] || key.toUpperCase().charCodeAt(0);
-    if (scope === undefined) {
+    if (typeof scope !== 'string') {
+      method = scope;
       scope = getScope();
     }
     if (!_handlers[key]) {
@@ -186,7 +187,9 @@
     for (i in _handlers[key]) {
       obj = _handlers[key][i];
       if (obj.scope === scope) {
-        _handlers[key][i] = {};
+        if (!method || obj.method === method) {
+          _handlers[key][i] = {};
+        }
       }
     }
   }

--- a/test/keymaster.html
+++ b/test/keymaster.html
@@ -232,6 +232,62 @@
         t.assertEqual(cntForScope2, 1);
       },
 
+      testUnbindKeyUnscopedWithMethod: function(t) {
+        key.setScope('all');
+        var cntForMethod1 = 0;
+        var cntForMethod2 = 0;
+        var method1 = function() { cntForMethod1++; }
+        var method2 = function() { cntForMethod2++; }
+
+        key('a', method1);
+        key('a', method2);
+        
+        // verify key is bound
+        keydown(65); keyup(65);
+
+        // verify key is bound
+        t.assertEqual(cntForMethod1, 1);
+        t.assertEqual(cntForMethod2, 1);
+
+        // verify unbind just unbinds the correct method
+        key.unbind('a', method1);
+        keydown(65); keyup(65);
+        t.assertEqual(cntForMethod1, 1);
+        t.assertEqual(cntForMethod2, 2);
+      },
+
+      testUnbindKeyScopedWithMethod: function(t){
+        key.setScope('all');
+        var cntForMethod1 = 0;
+        var cntForMethod2 = 0;
+        var method1 = function() { cntForMethod1++; }
+        var method2 = function() { cntForMethod2++; }
+
+        key('a', 'scope1', method1);
+        key('a', 'scope1', method2);
+        
+        // verify key is bound
+        key.setScope('scope1');
+        keydown(65); keyup(65);
+
+        // verify key is bound
+        t.assertEqual(cntForMethod1, 1);
+        t.assertEqual(cntForMethod2, 1);
+
+        // verify scope is set
+        key.setScope('scope2');
+        keydown(65); keyup(65);
+        t.assertEqual(cntForMethod1, 1);
+        t.assertEqual(cntForMethod2, 1);
+
+        // verify unbind just unbinds the correct method
+        key.unbind('a', 'scope1', method1);
+        key.setScope('scope1')
+        keydown(65); keyup(65);
+        t.assertEqual(cntForMethod1, 1);
+        t.assertEqual(cntForMethod2, 2);
+      },
+
       testDeleteScope: function(t){
         var sequence = '';
 


### PR DESCRIPTION
This is building upon #65 and #69. I've added a "method" argument so you can specify exactly which handler to remove, like in most event systems (e.g. `on('event', method)` / `off('event', method)`).

There's a bit of undefined behaviour in the unbind method which needs a design decision though. If the scope is not set, then calling just `unbind('a')` will only remove handlers for "a" in the current scope. I think I'd expect it to remove all handlers for "a", like calling `off('event')` in an event system. Thoughts?
