### PR TITLE
Use noConflict by default for CommonJS

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -221,6 +221,9 @@
   global.key.getPressedKeyCodes = getPressedKeyCodes;
   global.key.noConflict = noConflict;
 
-  if(typeof module !== 'undefined') module.exports = key;
+  if(typeof module !== 'undefined') {
+    module.exports = key;
+    noConflict();
+  }
 
 })(this);


### PR DESCRIPTION
Hey, Thomas!

When requiring a module with CommonJS style I generally assume it's not going to create any globals for me. Since I'll be assigning the required module to your own variable when requiring it anyway:

``` js
var key = require('keymaster');
```

I simply tweaked it to call `noConflict` if you're requiring it.

``` js
if(typeof module !== 'undefined') {
  module.exports = key;
  noConflict();
}
```

It's a silly little thing, but figured I'd propose this change if you want it. That's the pattern I've seen in other projects that do both, like backbone, etc: https://github.com/documentcloud/backbone/blob/master/backbone.js#L30
