### PR TITLE
key descriptions (e.g. 'up', 'space', etc) in key.isPressed()

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -29,6 +29,9 @@
       ';': 186, '\'': 222,
       '[': 219, ']': 221, '\\': 220
     },
+    code = function(x){
+      return _MAP[x] || x.toUpperCase().charCodeAt(0);
+    },
     _downKeys = [];
 
   for(k=1;k<20;k++) _MODIFIERS['f'+k] = 111+k;
@@ -136,7 +139,7 @@
       }
       // convert to keycode and...
       key = key[0]
-      key = _MAP[key] || key.toUpperCase().charCodeAt(0);
+      key = code(key);
       // ...store handler
       if (!(key in _handlers)) _handlers[key] = [];
       _handlers[key].push({ shortcut: keys[i], scope: scope, method: method, key: keys[i], mods: mods });
@@ -147,11 +150,7 @@
   // Converts strings into key codes.
   function isPressed(keyCode) {
       if (typeof(keyCode)=='string') {
-          if (keyCode.length == 1) {
-              keyCode = (keyCode.toUpperCase()).charCodeAt(0);
-          } else {
-              return false;
-          }
+        keyCode = code(keyCode);
       }
       return index(_downKeys, keyCode) != -1;
   }

--- a/test/keymaster.html
+++ b/test/keymaster.html
@@ -239,6 +239,10 @@
 
         keydown(66); keyup(66);
         t.assertFalse(key.isPressed(66));
+
+        keydown(38);
+        t.assertTrue(key.isPressed("up"));
+        keyup(38);
       },
 
       testGetPressedKeyCodes: function (t) {


### PR DESCRIPTION
Issue: key.isPressed() previously could only accept single-characters when given a string, so keys such as "up", "delete", and the like needed to be supplied with key codes. It’s resolved by making key.isPressed() understand what "up" is.

No support for combined keys or modifiers in isPressed() in this patch, but I could see how that might also be useful.

Why: I’m writing a game, and the key(keys, fn) handler reacted way slower than what I needed, so I am forced to check for key.isPressed() when I need to react to key presses, and I really don’t want to keep my own map of keys to keycodes when keymaster already has one.
