### PR TITLE
Extend keymaster to support dispatching key events to elements

### DIFF
--- a/selftest.html
+++ b/selftest.html
@@ -1,0 +1,137 @@
+<!html>
+<head>
+  <title>The Keymaster</title>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+</head>
+<body>
+  <script src="keymaster.js"></script>
+
+  <h1>
+    The Keymaster Self Test.
+  </h1>
+
+  <input type="text" placeholder="a text input"/>
+  <select><option></option><option>select</option></select>
+  <textarea placeholder="a textarea"></textarea>
+
+  <p>The Self Test simulated the first five items on this manual test list:</p>
+  <ol>
+    <li>Press 'c'. Nothing should be logged on console.</li>
+    <li>Press 'o' or Enter or Cursor &larr;. Console should log function call.</li>
+    <li>Press 'i'. Switches scope to 'issues'.</li>
+    <li>Press 'c'. Console should log function call.</li>
+    <li>Press 'o' or Enter or Cursor &larr;. Console should log function call.</li>
+    <li>Press and hold 'm'. Console should log a message every second.</li>
+    <li>Every second console should log a message listing all the currently pressed keycodes.</li>
+  </ol>
+
+  <p>
+    At any time, try pressing ⌘+right, shift+left or ctrl+shift+alt+d.
+  </p>
+  
+  <p>
+    When a input, a select or a textarea element is focused, key inputs should be ignored.
+  </p>
+
+  <script>
+    key('c', 'issues', function(){
+     console.log('c/issues');
+    });
+
+    key('command+r, ctrl+r', 'issues', function(){
+      console.log('Hijacked Command+R or Ctrl+R, damn!');
+      return false;
+    });
+    
+    key('i', function(){
+      key.setScope('issues');
+      console.log('Switched to "issues" scope. Command+R or Ctrl+R is now no longer reloading...');
+    });
+    
+    key('i', function(){
+      console.log('(example of multiple assignment)');
+    });
+
+    key('o, enter, left', function(){
+      console.log('o, enter or left pressed!');
+    });
+
+    key('ctrl+c', function(){
+      console.log('this is not the command line');
+    });
+
+    key('⌘+right,shift+left,ctrl+shift+alt+d', function(event){
+      console.log('command+right, or shift+left, or ctrl+shift+alt+d');
+      console.log('here is the event: ', event);
+      console.log('key.control', key.control);
+      console.log('key.ctrl', key.ctrl);
+      console.log('key.shift', key.shift);
+      console.log('key.alt', key.alt);
+      console.log('key["⌘"]', key["⌘"]);
+      return false; // prevent default && stop propagation
+    });
+
+    key('⌘+x, ctrl+x', function(event, handler){
+      console.log(handler.shortcut, handler.scope);
+      return false;
+    });
+
+    key('/', function(){ console.log('/') });
+    key('shift+]', function(){ console.log('shift+]') });
+
+    // set up for testing
+    var expected;
+    console.log = function(actual) {
+      var oneExpected;
+      if (typeof expected === 'string')
+        oneExpected = expected;
+      else
+        oneExpected = expected.shift();
+
+      if (oneExpected === actual) {
+        console.warn('PASS ' + actual);
+      } else {
+        console.error('FAIL ' + actual + ' !== ' + oneExpected);
+      }
+    }
+
+    // Now fire some events 
+    expected = undefined;
+    key('c', document.body);
+    expected = 'o, enter or left pressed!';
+    key('o, enter, left', document.body);
+    expected = [
+      'Switched to "issues" scope. Command+R or Ctrl+R is now no longer reloading...',
+      '(example of multiple assignment)'
+    ],
+    key('i', document.body);
+    expected = 'c/issues'
+    key('c', document.body);
+    expected = 'this is not the command line';
+    key('ctrl+c', document.body);
+    expected = 'o, enter or left pressed!';
+    key('o, enter, left', document.body);   
+    expected = [
+      'command+right, or shift+left, or ctrl+shift+alt+d',
+      'here is the event: ' ,
+      'key.control',
+      'key.ctrl',
+      'key.shift',
+      'key.alt',
+      'key["⌘"]',
+      'command+right, or shift+left, or ctrl+shift+alt+d',
+      'here is the event: ' ,
+      'key.control',
+      'key.ctrl',
+      'key.shift',
+      'key.alt',
+      'key["⌘"]',
+    ]; 
+    key('⌘+right,ctrl+shift+alt+d', document.body);
+
+    // document.onkeydown = function(event){
+    //  console.log(event.keyCode);
+    // }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
 You may not care for this direction, but FYI.

Extend keymaster to support dispatching key events to elements. 
Overload key() to include key(descriptor, view, element) 
where |descriptor| is the same as the shortcut definition version, 
|view| is the dispatch view (defaults to 'window'), 
|element| is the dispatch target.

Add selftest.html, modified from test.html to issue console.warn
for passing tests and console.error for failures.

Tests pass but I've not driven this model out on the road yet.
