### PR TITLE
Updates the makefile comment to explicitly suggest v1 of uglifyjs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-# npm install uglify-js -g
+# npm install uglify-js@1 -g
 default:
 	uglifyjs -o keymaster.min.js keymaster.js


### PR DESCRIPTION
The default uglifyjs package is now v2, this means that the generated
(minified) js looks very different to what was presumably intended
(based on the existing .min.js file)
