### PR TITLE
Make `unbind` function consistent with `key` function

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -162,7 +162,7 @@
   };
 
   // unbind all handlers for given key in current scope
-  function unbindKey(key, scope) {
+  function unbind(key, scope) {
     var keys = key.split('+'),
       mods = [],
       i, obj;
@@ -188,6 +188,13 @@
       }
     }
   };
+
+  function unbindKey(key, scope) {
+    var keys = getKeys(key);
+    for (var i = 0; i < keys.length; i++) {
+      unbind(keys[i], scope);
+    }
+  }
 
   // Returns true if the key with code 'keyCode' is currently down
   // Converts strings into key codes.

--- a/test/keymaster.html
+++ b/test/keymaster.html
@@ -77,6 +77,60 @@
         keydown(65);
         keyup(65);
         t.assertEqual(1, cnt);
+
+        cnt = 0;
+        key('a, b', function(){ cnt++ });
+        keydown(65);
+        keyup(65);
+        keydown(66);
+        keyup(66);
+        t.assertEqual(2, cnt);
+        key.unbind('a, b');
+        keydown(65);
+        keyup(65);
+        keydown(66);
+        keyup(66);
+        t.assertEqual(2, cnt);
+
+        cnt = 0;
+        key('a, b', function() { cnt++ });
+        keydown(65);
+        keyup(65);
+        keydown(66);
+        keyup(66);
+        t.assertEqual(2, cnt);
+        key.unbind('a');
+        keydown(65);
+        keyup(65);
+        keydown(66);
+        keyup(66);
+        t.assertEqual(3, cnt);
+        key.unbind('b');
+        keydown(65);
+        keyup(65);
+        keydown(66);
+        keyup(66);
+        t.assertEqual(3, cnt);
+
+        cnt = 0;
+        key('a, b', function() { cnt++ });
+        keydown(65);
+        keyup(65);
+        keydown(66);
+        keyup(66);
+        t.assertEqual(2, cnt);
+        key.unbind('b');
+        keydown(65);
+        keyup(65);
+        keydown(66);
+        keyup(66);
+        t.assertEqual(3, cnt);
+        key.unbind('a');
+        keydown(65);
+        keyup(65);
+        keydown(66);
+        keyup(66);
+        t.assertEqual(3, cnt);
       },
 
       testShortcutWithModifiers: function(t){


### PR DESCRIPTION
Previously, the `key` function and `unbind` function were assymetrical
so the following ignored the clear meaning intended:

```
key('a, b', function() { alert("You Hit A or B!") });
# User Interaction...
key.unbind('a, b')
```

Only `a` was unbound.

The code was almost 100% there; I just mirrored the behavior I saw in
the `assignKeys` function.

The code is tested (failing tests were produced first).
