### PR TITLE
Unbind wasn't working for multiple key combos

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -165,28 +165,34 @@
 
   // unbind all handlers for given key in current scope
   function unbindKey(key, scope) {
-    var keys = key.split('+'),
+    var multipleKeys, keys,
       mods = [],
-      i, obj;
+      i, j, obj;
 
-    if (keys.length > 1) {
-      mods = getMods(keys);
-      key = keys[keys.length - 1];
-    }
+    multipleKeys = getKeys(key);
 
-    key = code(key);
+    for (j = 0; j < multipleKeys.length; j++) {
+      keys = multipleKeys[j].split('+');
 
-    if (scope === undefined) {
-      scope = getScope();
-    }
-    if (!_handlers[key]) {
-      return;
-    }
-    for (i in _handlers[key]) {
-      obj = _handlers[key][i];
-      // only clear handlers if correct scope and mods match
-      if (obj.scope === scope && compareArray(obj.mods, mods)) {
-        _handlers[key][i] = {};
+      if (keys.length > 1) {
+        mods = getMods(keys);
+        key = keys[keys.length - 1];
+      }
+
+      key = code(key);
+
+      if (scope === undefined) {
+        scope = getScope();
+      }
+      if (!_handlers[key]) {
+        return;
+      }
+      for (i in _handlers[key]) {
+        obj = _handlers[key][i];
+        // only clear handlers if correct scope and mods match
+        if (obj.scope === scope && compareArray(obj.mods, mods)) {
+          _handlers[key][i] = {};
+        }
       }
     }
   };

--- a/test/keymaster.html
+++ b/test/keymaster.html
@@ -174,6 +174,31 @@
         t.assertEqual(1, cntCommandCtrlAltShiftA);
       },
 
+      testUnbindWithModifiersMultiple: function(t){
+        var cntA = 0, cntShiftA = 0, cntCtrlShiftA = 0;
+        key('a', function(){ cntA++ });
+        key('shift+a', function(){ cntShiftA++ });
+        key('ctrl+shift+a', function(){ cntCtrlShiftA++ });
+
+        keydown(65); keyup(65);
+        keydown(KEYS.shift); keydown(65, [16]); keyup(65); keyup(KEYS.shift);
+        keydown(KEYS.shift); keydown(KEYS.ctrl); keydown(65, [16, 17]); keyup(65); keyup(KEYS.shift); keyup(KEYS.ctrl);
+
+        t.assertEqual(1, cntA);
+        t.assertEqual(1, cntShiftA);
+        t.assertEqual(1, cntCtrlShiftA);
+
+        key.unbind('a, shift+a, ctrl+shift+a');
+
+        keydown(65); keyup(65);
+        keydown(KEYS.shift); keydown(65, [16]); keyup(65); keyup(KEYS.shift);
+        keydown(KEYS.shift); keydown(KEYS.ctrl); keydown(65, [16, 17]); keyup(65); keyup(KEYS.shift); keyup(KEYS.ctrl);
+
+        t.assertEqual(1, cntA);
+        t.assertEqual(1, cntShiftA);
+        t.assertEqual(1, cntCtrlShiftA);
+      },
+
       testFancyModifierKeys: function(t){
         var sequence = '';
         key('⌃+a', function(){ sequence += 'a' });


### PR DESCRIPTION
The documentation shows that you should be able to call unbind with multiple shortcuts at the same time, just like in `assignKey`: `unbind('a, shift+b, ctrl+c')`. This was not working, since the `unbindKey` function simply didn't split the provided `key` parameter by comma (using the `getKeys()` function).

I've fixed this and also updated the unit tests. Basically, I've put a for loop around the current functionality to call it for each key combo that was provided.
