### PR TITLE
Add support for iframe key capture.

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -4,6 +4,7 @@
 
 ;(function(global){
   var k,
+    _document = document,
     _handlers = {},
     _mods = { 16: false, 18: false, 17: false, 91: false },
     _scope = 'all',
@@ -219,6 +220,10 @@
   // initialize key.<modifier> to false
   for(k in _MODIFIERS) assignKey[k] = false;
 
+  // set the context, useful when binding the key events to an iframe.
+  function setDocument(doc) { _document = doc; }
+  function getDocument(doc) { return _document; }
+
   // set current scope (default 'all')
   function setScope(scope){ _scope = scope || 'all' };
   function getScope(){ return _scope || 'all' };
@@ -264,8 +269,8 @@
   };
 
   // set the handlers globally on document
-  addEvent(document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
-  addEvent(document, 'keyup', clearModifier);
+  addEvent(_document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
+  addEvent(_document, 'keyup', clearModifier);
 
   // reset modifiers to false whenever the window is (re)focused.
   addEvent(window, 'focus', resetModifiers);

--- a/keymaster.js
+++ b/keymaster.js
@@ -2,9 +2,11 @@
 //     (c) 2011-2013 Thomas Fuchs
 //     keymaster.js may be freely distributed under the MIT license.
 
-;(function(global){
+keymaster = function(win) {
   var k,
-    _document = document,
+    key,
+    _window = win || window,
+    _document,
     _handlers = {},
     _mods = { 16: false, 18: false, 17: false, 91: false },
     _scope = 'all',
@@ -76,7 +78,7 @@
     if(key == 93 || key == 224) key = 91; // right command on webkit, command on Gecko
     if(key in _mods) {
       _mods[key] = true;
-      // 'assignKey' from inside this closure is exported to window.key
+      // 'assignKey' from inside this closure is exported to _window.key
       for(k in _MODIFIERS) if(_MODIFIERS[k] == key) assignKey[k] = true;
       return;
     }
@@ -220,10 +222,6 @@
   // initialize key.<modifier> to false
   for(k in _MODIFIERS) assignKey[k] = false;
 
-  // set the context, useful when binding the key events to an iframe.
-  function setDocument(doc) { _document = doc; }
-  function getDocument(doc) { return _document; }
-
   // set current scope (default 'all')
   function setScope(scope){ _scope = scope || 'all' };
   function getScope(){ return _scope || 'all' };
@@ -265,37 +263,43 @@
     if (object.addEventListener)
       object.addEventListener(event, method, false);
     else if(object.attachEvent)
-      object.attachEvent('on'+event, function(){ method(window.event) });
+      object.attachEvent('on'+event, function(){ method(_window.event) });
   };
 
-  // set the handlers globally on document
-  addEvent(_document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
+  // set the handlers _windowly on document
+  // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
+  _document = _window.document;
+  addEvent(_document, 'keydown', function(event) { dispatch(event) });
   addEvent(_document, 'keyup', clearModifier);
 
-  // reset modifiers to false whenever the window is (re)focused.
-  addEvent(window, 'focus', resetModifiers);
+  // reset modifiers to false whenever the _window is (re)focused.
+  addEvent(_window, 'focus', resetModifiers);
 
   // store previously defined key
-  var previousKey = global.key;
+  var previousKey = _window.key;
 
   // restore previously defined key and return reference to our key object
   function noConflict() {
-    var k = global.key;
-    global.key = previousKey;
+    var k = _window.key;
+    _window.key = previousKey;
     return k;
   }
 
-  // set window.key and window.key.set/get/deleteScope, and the default filter
-  global.key = assignKey;
-  global.key.setScope = setScope;
-  global.key.getScope = getScope;
-  global.key.deleteScope = deleteScope;
-  global.key.filter = filter;
-  global.key.isPressed = isPressed;
-  global.key.getPressedKeyCodes = getPressedKeyCodes;
-  global.key.noConflict = noConflict;
-  global.key.unbind = unbindKey;
+  // set _window.key and _window.key.set/get/deleteScope, and the default filter
+  key = assignKey;
+  key.setScope = setScope;
+  key.getScope = getScope;
+  key.deleteScope = deleteScope;
+  key.filter = filter;
+  key.isPressed = isPressed;
+  key.getPressedKeyCodes = getPressedKeyCodes;
+  key.noConflict = noConflict;
+  key.unbind = unbindKey;
+
+  // export key to the global scope
+  _window.key = key
 
   if(typeof module !== 'undefined') module.exports = key;
+}
 
-})(this);
+keymaster(this);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ys-keymaster",
+  "name": "keymaster",
   "description": "library for defining and dispatching keyboard shortcuts",
   "version": "1.6.1",
   "author": "Thomas Fuchs <thomas@slash7.com> (http://mir.aculo.us)",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "keymaster",
+  "name": "ys-keymaster",
   "description": "library for defining and dispatching keyboard shortcuts",
   "version": "1.6.1",
   "author": "Thomas Fuchs <thomas@slash7.com> (http://mir.aculo.us)",


### PR DESCRIPTION
Usage:

```
ikey = keymaster(
  document.getElementById('#iframe').contentWindow
);

ikey('ctrl+a', iframe_handler);

// Still compatible with the previous api.
key('ctrl+b', host_window_handler);
```
