### PR TITLE
Export `global.key` explicitly (makes keymaster work w/ chrome apps & browserify)

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -291,6 +291,6 @@
   global.key.noConflict = noConflict;
   global.key.unbind = unbindKey;
 
-  if(typeof module !== 'undefined') module.exports = key;
+  if(typeof module !== 'undefined') module.exports = global.key;
 
 })(this);


### PR DESCRIPTION
Trivial change, makes the library work when `this` is not actually `window` or `global`. This happens with the popular build tool [browserify](http://browserify.org/).
