### PR TITLE
Moved the install script from pure Makefile to npm.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 keymaster.min.js
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,2 @@
-# To run this, you'll need to install UglifyJS:
-# npm install uglify-js@1 -g
 default:
-	uglifyjs -o keymaster.min.js keymaster.js
+	npm install

--- a/package.json
+++ b/package.json
@@ -7,5 +7,7 @@
     "type": "git",
     "url": "https://github.com/madrobby/keymaster"
   },
+  "dependencies": { "uglify-js": "1" },
+  "scripts": { "install": "uglifyjs -o keymaster.min.js keymaster.js" },
   "main": "./keymaster.js"
 }


### PR DESCRIPTION
`uglify-js` is now included locally, instead of pushed as a globally installed package (an anti-pattern in my book).

Running `make` still ends up with a minified file, by delegating through `npm install`.

A big difference: `npm install` is automatically invoked when including this from another npm package, `make` is not.
