### PR TITLE
set module.exports to "global.key" rather than just "key" to play nice w...

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -291,6 +291,6 @@
   global.key.noConflict = noConflict;
   global.key.unbind = unbindKey;
 
-  if(typeof module !== 'undefined') module.exports = key;
+  if(typeof module !== 'undefined') module.exports = global.key;
 
 })(this);


### PR DESCRIPTION
Using: module.exports = global.key fixed a problem I observed at runtime when using a bundle built with browserify.
