### PR TITLE
Fix module.exports for Browserify

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -291,6 +291,6 @@
   global.key.noConflict = noConflict;
   global.key.unbind = unbindKey;
 
-  if(typeof module !== 'undefined') module.exports = key;
+  if(typeof module !== 'undefined') module.exports = assignKey;
 
 })(this);


### PR DESCRIPTION
The global is not window in Browserify so the key variable is undefined. Use local assignKey to define the export.
