### PR TITLE
Proper unbinding of keys.

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -188,6 +188,9 @@
         return;
       }
       for (i in _handlers[key]) {
+        if (!_handlers[key].hasOwnProperty(i)) {
+          continue;
+        }
         obj = _handlers[key][i];
         // only clear handlers if correct scope and mods match
         if (obj.scope === scope && compareArray(obj.mods, mods)) {


### PR DESCRIPTION
key.unbind tries to test obj.scope even when obj is undefined, other way to fix: https://github.com/madrobby/keymaster/pull/111
