### PR TITLE
Add 'meta' to _MODIFIERS dictionary

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -12,7 +12,7 @@
       '⇧': 16, shift: 16,
       '⌥': 18, alt: 18, option: 18,
       '⌃': 17, ctrl: 17, control: 17,
-      '⌘': 91, command: 91
+      '⌘': 91, command: 91, meta: 91
     },
     // special keys
     _MAP = {


### PR DESCRIPTION
This allows users to write shortcuts like `meta+s`, rather than having to use  `command+s`. It would be nice to have this over at [Ghost](/tryghost/ghost), where we refer to `meta` in our shortcuts documentation, not `command`.