### PR TITLE
Add support for modifier keys in isPressed

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -30,7 +30,7 @@
       '[': 219, ']': 221, '\\': 220
     },
     code = function(x){
-      return _MAP[x] || x.toUpperCase().charCodeAt(0);
+      return _MAP[x] || _MODIFIERS[x] || x.toUpperCase().charCodeAt(0);
     },
     _downKeys = [];
 


### PR DESCRIPTION
Adds support for string modifier keys to isPressed.

Currently, key.isPressed('command') does not work when key.isPressed(91) does.
