### PR TITLE
Small fix - use `window.document` instead of `document`

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -264,8 +264,8 @@
   };
 
   // set the handlers globally on document
-  addEvent(document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
-  addEvent(document, 'keyup', clearModifier);
+  addEvent(window.document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
+  addEvent(window.document, 'keyup', clearModifier);
 
   // reset modifiers to false whenever the window is (re)focused.
   addEvent(window, 'focus', resetModifiers);


### PR DESCRIPTION
Accessing to `document` object throws an error in `node-webkit`. Now this library can be compatible with it.
