### PR TITLE
fix adding event infinite loop

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -64,7 +64,7 @@
 
   // handle keydown event
   function dispatch(event) {
-    var key, handler, k, i, modifiersMatch, scope;
+    var key, handler, k, i, modifiersMatch, scope, numEvents;
     key = event.keyCode;
 
     if (index(_downKeys, key) == -1) {
@@ -90,8 +90,9 @@
 
     scope = getScope();
 
+    numEvents = _handlers[key].length;
     // for each potential shortcut
-    for (i = 0; i < _handlers[key].length; i++) {
+    for (i = 0; i < numEvents; i++) {
       handler = _handlers[key][i];
 
       // see if it's in the current scope


### PR DESCRIPTION
Our team noticed if a handler adds new handlers to the same listener, all new handlers will be executed immediately.

I believe the expected behavior would be any handlers that were already listening when an event occurred should fire. Any new handlers added on account of a keystroke should not fire.