### PR TITLE
Pass in 'dispatch' as the callback directly

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -264,7 +264,7 @@
   };
 
   // set the handlers globally on document
-  addEvent(document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
+  addEvent(document, 'keydown', dispatch);
   addEvent(document, 'keyup', clearModifier);
 
   // reset modifiers to false whenever the window is (re)focused.


### PR DESCRIPTION
Currently there seems to be an anonymous callback that's basically calling the
`dispatch` function. Updating that to pass in `dispatch` as the callback
directly.