### PR TITLE
Add 'deleteScope' Method to Readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -108,6 +108,10 @@ key('o, enter', 'files', function(){ /* do something else */ });
 
 // set the scope (only 'all' and 'issues' shortcuts will be honored)
 key.setScope('issues'); // default scope is 'all'
+
+// remove all events that are set in 'issues' scope
+key.deleteScope('issues');
+
 ```
 
 


### PR DESCRIPTION
I've noticed in the project source that there is a very useful `deleteScope` method for removing all events bound in a scope. 

I was struggling with keeping track of each bound key separately and found that this saves me a bit of time. 

Perhaps we can include in the docs so others can find this functionality more easily?