### PR TITLE
Replaced this context with empty object, since this is undefined

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -293,4 +293,4 @@
 
   if(typeof module !== 'undefined') module.exports = assignKey;
 
-})(this);
+})({});


### PR DESCRIPTION
I observed a problem with keymaster, when using it with bable. 
Function initialized with ```this```, but since it defaults to undefined, I get a runtime error. 

Replaced with with empty object. 