### PR TITLE
Reset pressed keys when reseting modifiers

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -134,6 +134,7 @@
   function resetModifiers() {
     for(k in _mods) _mods[k] = false;
     for(k in _MODIFIERS) assignKey[k] = false;
+    _downKeys = [];
   };
 
   // parse and assign shortcut

--- a/test/keymaster.html
+++ b/test/keymaster.html
@@ -48,6 +48,12 @@
       (el||document).dispatchEvent(event);
     }
 
+    function triggerEvent(eventName, el){
+      var event = document.createEvent('Event');
+      event.initEvent(eventName, true, true);
+      (el||document).dispatchEvent(event);
+    }
+
     var KEYS = {
       '⇧': 16, shift: 16,
       '⌥': 18, alt: 18, option: 18,
@@ -402,6 +408,14 @@
         t.assertTrue(pressedKeys.indexOf(16) >= 0);
         t.assertTrue(pressedKeys !== otherKeys);
         keyup(65); keyup(KEYS.shift);
+
+        keydown(65);
+        t.assertTrue(key.isPressed(65));
+        t.assertEqual(key.getPressedKeyCodes().length, 1);
+        triggerEvent('focus', window);
+        t.assertFalse(key.isPressed(65));
+        t.assertEqual(key.getPressedKeyCodes().length, 0);
+        keyup(65);
       },
 
       testNoConflict: function(t) {


### PR DESCRIPTION
aka when re-focusing window.

## Teh problem
In our app we use `key.isPressed(KEYS.ALT)` to detect when `alt` is pressed to execute some alternate-power-user-hidden actions. 💪 

We noticed that very often `alt` is being detected as pressed while it was in fact: Not pressed. 😱

## Teh steps
This can be reproducible quite easily (especially when `alt` is being used for Alfred or Spotlight):
- Focus page/app
- Press and hold `alt`
- Unfocus page/app (can be by focusing dev tools)
- Release `alt`
- Focus page/app
- `console.log(key.isPressed(18), key.getPressedKeyCodes())`.

In long-lived apps, you’ll notice that `key.getPressedKeyCodes()` tends to get bigger and bigger. The only way to reset it is finding and pressing all the keys present in the array. 😅

## Teh fix
Reseting `_downKeys` on `resetModifiers` fixes that. 🤘 

I can’t really think of a false-positive or unexpected behaviour since `key.isPressed` don’t work for keys pressed prior to focusing page/app.