### PR TITLE
Add 'license' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
     "type": "git",
     "url": "https://github.com/madrobby/keymaster"
   },
-  "main": "./keymaster.js"
+  "main": "./keymaster.js",
+  "license": "MIT"
 }


### PR DESCRIPTION
Add the [license](https://docs.npmjs.com/files/package.json#license) information to `package.json` to allow projects using `keymaster` to perform licenses checks.