### PR TITLE
docs: Fix simple typo, neccessary -> necessary

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -101,7 +101,7 @@
         for(k in _mods)
           if((!_mods[k] && index(handler.mods, +k) > -1) ||
             (_mods[k] && index(handler.mods, +k) == -1)) modifiersMatch = false;
-        // call the handler and stop the event if neccessary
+        // call the handler and stop the event if necessary
         if((handler.mods.length == 0 && !_mods[16] && !_mods[18] && !_mods[17] && !_mods[91]) || modifiersMatch){
           if(handler.method(event, handler)===false){
             if(event.preventDefault) event.preventDefault();


### PR DESCRIPTION
There is a small typo in keymaster.js.

Should read `necessary` rather than `neccessary`.

