### PR TITLE
Guard against use of "document"

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -264,8 +264,10 @@
   };
 
   // set the handlers globally on document
-  addEvent(document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
-  addEvent(document, 'keyup', clearModifier);
+  if (document) {
+    addEvent(document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
+    addEvent(document, 'keyup', clearModifier);
+  }
 
   // reset modifiers to false whenever the window is (re)focused.
   addEvent(window, 'focus', resetModifiers);

--- a/keymaster.js
+++ b/keymaster.js
@@ -264,7 +264,7 @@
   };
 
   // set the handlers globally on document
-  if (window && window.document) {
+  if (typeof window !== 'undefined' && window.document) {
     addEvent(window.document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
     addEvent(window.document, 'keyup', clearModifier);
   }

--- a/keymaster.js
+++ b/keymaster.js
@@ -264,7 +264,7 @@
   };
 
   // set the handlers globally on document
-  if (window.document) {
+  if (window && window.document) {
     addEvent(window.document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
     addEvent(window.document, 'keyup', clearModifier);
   }

--- a/keymaster.js
+++ b/keymaster.js
@@ -264,9 +264,9 @@
   };
 
   // set the handlers globally on document
-  if (document) {
-    addEvent(document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
-    addEvent(document, 'keyup', clearModifier);
+  if (window.document) {
+    addEvent(window.document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
+    addEvent(window.document, 'keyup', clearModifier);
   }
 
   // reset modifiers to false whenever the window is (re)focused.

--- a/keymaster.js
+++ b/keymaster.js
@@ -267,10 +267,10 @@
   if (typeof window !== 'undefined' && window.document) {
     addEvent(window.document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
     addEvent(window.document, 'keyup', clearModifier);
+    
+    // reset modifiers to false whenever the window is (re)focused.
+    addEvent(window, 'focus', resetModifiers);
   }
-
-  // reset modifiers to false whenever the window is (re)focused.
-  addEvent(window, 'focus', resetModifiers);
 
   // store previously defined key
   var previousKey = global.key;


### PR DESCRIPTION
For use with SvelteKit, where the js code is run on the server.